### PR TITLE
Fix download URL for post-0.x versions.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,11 @@ function download (ver, cb) {
             break;
         case 'x64':
             fname += '-x64.msi';
-            url += 'x64/' + fname;
+            if (ver.substr(0, 1) === '0') {
+                url += 'x64/' + fname;
+            } else {
+                url += fname;
+            }
             break;
         default:
             cb()
@@ -90,7 +94,7 @@ function isStableVersion (ver) {
 function getLatest (versions, onlyStable, cb) {
     var currVer = '0.0.0',
         maxVer = '0.0.0';
-    
+
     for (var i = 0, l = versions.length; i < l; i++) {
         currVer = versions[i];
         if (!onlyStable || isStableVersion(currVer)) {


### PR DESCRIPTION
64-bit downloads are no longer in a "x64" subdirectory after 0.x.
